### PR TITLE
Changes in construction of Macaulay matrix

### DIFF
--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -706,7 +706,7 @@ noetherianOperators (Ideal, Ideal) := List => opts -> (I, P) -> (
     local M; local M'; local K; local bd; local bx;
     numOps := -1;
     for i in 1..opts.DegreeLimit do (
-        bx = flatten entries sub(basis(0,i - 1,R),S);
+        bx = flatten entries basis(0,i - 1,S);
         bd = basis(0,i,S);
         M = diff(bd, transpose matrix {flatten (table(bx,SI_*,(i,j) -> i*j))});
         M' = sub(M, kP);


### PR DESCRIPTION
The Macaulay matrix in our implementation has too many rows compared to the paper, at least in the symbolic algorithm.

Currently if the ideal in question is positive dimensional, the rows of the Macaulay matrix consists of generators and monomial multiples in all variables. Shouldn't it be monomial multiples in only the dependent variables? Does anyone remember if there was a good reason why we did it like this?

Also, the numerical version also uses monomial multiples in all variables, not just dependent ones. This however seems to agree with the paper. Should it be changed though?